### PR TITLE
Update pay.ts

### DIFF
--- a/ironfish-cli/src/commands/accounts/pay.ts
+++ b/ironfish-cli/src/commands/accounts/pay.ts
@@ -41,7 +41,7 @@ export class Pay extends IronfishCommand {
     }),
     fee: flags.string({
       char: 'o',
-      description: 'the fee amount in Ore',
+      description: 'the fee amount in IRON',
     }),
     memo: flags.string({
       char: 'm',


### PR DESCRIPTION

![ORE error in fee description](https://user-images.githubusercontent.com/42167577/144764122-18383346-cacf-4350-ade2-7c6a4cb7e3ea.jpg)

The description of the _fee_ argument is wrong. The software considers the fees in IRON, not in ORE.
Changed the description.